### PR TITLE
fix : Caching return type error 해결 

### DIFF
--- a/Auth-Server/src/main/java/com/dju/gdsc/domain/member/model/PositionType.java
+++ b/Auth-Server/src/main/java/com/dju/gdsc/domain/member/model/PositionType.java
@@ -1,5 +1,5 @@
 package com.dju.gdsc.domain.member.model;
 
 public enum PositionType {
-    Beginner,Backend,Frontend,Ml,Design,Android
+    Beginner,Backend,Frontend,Ml,Design,Android,IOS
 }

--- a/Auth-Server/src/main/java/com/dju/gdsc/domain/oauth/service/CustomOAuth2UserService.java
+++ b/Auth-Server/src/main/java/com/dju/gdsc/domain/oauth/service/CustomOAuth2UserService.java
@@ -86,7 +86,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         // 멤버 info 도 같이 만들기
         return memberRepository.saveAndFlush(user);
     }
-    @CachePut(cacheNames = "memberCaching", key = "#userInfo.id")
+   
     public Member updateUser(Member user, OAuth2UserInfo userInfo) {
         if (userInfo.getName() != null && !user.getUsername().equals(userInfo.getName())) {
             user.setUsername(userInfo.getName());

--- a/Auth-Server/src/main/java/com/dju/gdsc/domain/oauth/service/CustomOAuth2UserService.java
+++ b/Auth-Server/src/main/java/com/dju/gdsc/domain/oauth/service/CustomOAuth2UserService.java
@@ -65,7 +65,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         return UserPrincipal.create(savedUser, user.getAttributes());
     }
-    @CacheEvict(cacheNames = "memberCaching", key = "#userInfo.id")
+  
     public Member createUser(OAuth2UserInfo userInfo, ProviderType providerType) {
         LocalDateTime now = LocalDateTime.now();
         MemberInfo memberInfo = new MemberInfo();
@@ -86,7 +86,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         // 멤버 info 도 같이 만들기
         return memberRepository.saveAndFlush(user);
     }
-   
+
     public Member updateUser(Member user, OAuth2UserInfo userInfo) {
         if (userInfo.getName() != null && !user.getUsername().equals(userInfo.getName())) {
             user.setUsername(userInfo.getName());

--- a/Auth-Server/src/test/java/com/dju/gdsc/domain/oauth/controller/RefreshControllerTest.java
+++ b/Auth-Server/src/test/java/com/dju/gdsc/domain/oauth/controller/RefreshControllerTest.java
@@ -20,6 +20,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;


### PR DESCRIPTION
## 작업 내용 (Content)
- CustomOAuth2UserService . java file 에서 Member Oauth2 Login 시 cache Put을 해줬었는데 이런 경우 Member type을 return 하는 update func 과 memberCaching 을 사용하는 다른 controller 의 경우 Dto type이라서 생기는 오류 1차적인 해결  



## 기타 사항 (Etc)
- 사실 service 딴에서 나오는 객체를 전부 Member 로 바꿔야 하는게 맞는데... 레거시 한 코드를 언제 다고치나.. ㅠㅠ

## Merge 전 필요 작업 (Checklist before merge)
- [ ] 예) XX 테이블 추가, 앱 배포 등
- [ ] eg) Create XX table, Deploy app etc

## Merge 후 필요 작업 (Checklist after merge)
- PR이 생성되면 코드 리뷰 요청한 개발자에게 슬랙으로 알려주세요.